### PR TITLE
Expose raw pixel data via the Mat::ptr methods

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -41,7 +41,7 @@ fn main() {
         ("core", vec!["core/types_c.h", "core/core.hpp" ]), // utility, base
         ("imgproc", vec![ "imgproc/types_c.h", "imgproc/imgproc_c.h",
                             "imgproc/imgproc.hpp" ]),
-        ("highgui", vec![   "highgui/cap_ios.h", 
+        ("highgui", vec![   "highgui/cap_ios.h",
                             "highgui/highgui.hpp",
                             "highgui/highgui_c.h",
                             //"highgui/ios.h"


### PR DESCRIPTION
- Change the `parse_type` ordering to recognize primitives first.
- Add the ability to ignore/skip functions based on arbitrary filters.
- Rename `Mat::ptr` overloads so Rust doesn't complain about them.

This should fix https://github.com/kali/opencv-rust/issues/17